### PR TITLE
Localize UI text to Japanese

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,7 +21,7 @@ const App: React.FC = () => {
       const results = await searchInventory(filters, sort);
       setInventory(results);
     } catch (err) {
-      setError('Failed to fetch inventory. Please try again later.');
+      setError('在庫情報の取得に失敗しました。時間をおいて再度お試しください。');
       console.error(err);
     } finally {
       setIsLoading(false);
@@ -47,10 +47,10 @@ const App: React.FC = () => {
       <main className="container mx-auto px-4 py-8">
         <div className="text-center mb-12">
           <h1 className="text-4xl md:text-5xl font-extrabold text-slate-900 leading-tight">
-            Find Your <span className="text-indigo-600">Prize</span>, Instantly.
+            欲しい<span className="text-indigo-600">賞品</span>を、最短で見つける。
           </h1>
           <p className="mt-4 text-lg text-slate-600 max-w-2xl mx-auto">
-            Discover and reserve leftover lottery prizes from stores near you. No more endless searching.
+            近くの店舗に眠る一番くじの在庫をサッと検索し、すぐに取り置き予約。もう探し回る必要はありません。
           </p>
         </div>
         
@@ -88,3 +88,4 @@ const App: React.FC = () => {
 };
 
 export default App;
+

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,9 +5,10 @@ export const Footer: React.FC = () => {
     return (
         <footer className="bg-slate-100 border-t border-slate-200">
             <div className="container mx-auto px-4 py-6 text-center text-sm text-slate-500">
-                <p>&copy; {new Date().getFullYear()} KujiLink. All rights reserved.</p>
-                <p className="mt-1">"Ichiban Kuji" is a registered trademark of its respective owner. This is an independent platform.</p>
+                <p>&copy; {new Date().getFullYear()} KujiLink. 無断転載を禁じます。</p>
+                <p className="mt-1">「一番くじ」は各権利者の登録商標です。本サービスは非公式のファン向けプラットフォームです。</p>
             </div>
         </footer>
     );
 };
+

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,9 +12,9 @@ export const Header: React.FC = () => {
             <span className="text-2xl font-bold text-slate-900">KujiLink</span>
           </div>
           <nav className="flex items-center gap-4">
-            <a href="#" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">For Stores</a>
+            <a href="#" className="text-sm font-medium text-slate-600 hover:text-indigo-600 transition-colors">店舗さま向け</a>
             <button className="bg-indigo-600 text-white px-4 py-2 rounded-md text-sm font-semibold hover:bg-indigo-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-              Login
+              ログイン
             </button>
           </nav>
         </div>
@@ -22,3 +22,4 @@ export const Header: React.FC = () => {
     </header>
   );
 };
+

--- a/components/InventoryCard.tsx
+++ b/components/InventoryCard.tsx
@@ -4,6 +4,15 @@ import { MapPinIcon } from './icons/MapPinIcon';
 import { StarIcon } from './icons/StarIcon';
 import { CheckBadgeIcon } from './icons/CheckBadgeIcon';
 
+const currencyFormatter = new Intl.NumberFormat('ja-JP', {
+  style: 'currency',
+  currency: 'JPY',
+  maximumFractionDigits: 0,
+});
+
+const formatPrizeGrade = (grade: InventoryItem['prize']['grade']): string =>
+  grade === 'Last One' ? 'ラストワン賞' : `${grade}賞`;
+
 interface InventoryCardProps {
   item: InventoryItem;
   onSelect: () => void;
@@ -21,11 +30,11 @@ export const InventoryCard: React.FC<InventoryCardProps> = ({ item, onSelect }) 
       <div className="relative">
         <img src={photos[0]} alt={prize.title} className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300" />
         <div className={`absolute top-2 left-2 px-2 py-1 text-xs font-bold text-white rounded-full ${isRare ? 'bg-amber-500' : 'bg-indigo-500'}`}>
-          {prize.grade} Prize
+          {formatPrizeGrade(prize.grade)}
         </div>
         {quantity === 1 && (
             <div className="absolute top-2 right-2 px-2 py-1 text-xs font-bold text-white rounded-full bg-red-600">
-                Only 1 left!
+                残り1点！
             </div>
         )}
       </div>
@@ -35,7 +44,7 @@ export const InventoryCard: React.FC<InventoryCardProps> = ({ item, onSelect }) 
         
         <div className="flex items-center justify-between mt-4">
             <div className="flex items-center gap-2">
-                <p className="text-xl font-extrabold text-indigo-600">${price.toFixed(2)}</p>
+                <p className="text-xl font-extrabold text-indigo-600">{currencyFormatter.format(price)}</p>
             </div>
             <div className="flex items-center text-sm text-slate-600 gap-1">
                 <MapPinIcon className="w-4 h-4 text-slate-400" />
@@ -47,7 +56,7 @@ export const InventoryCard: React.FC<InventoryCardProps> = ({ item, onSelect }) 
             <div className="flex items-center gap-1.5 truncate">
                 <p className="font-semibold text-slate-700 truncate">{store.name}</p>
                 {/* FIX: The `title` prop is not a valid prop for SVG components. Wrapped the icon in a `span` and moved the title attribute to it to provide the tooltip. */}
-                {store.verified && <span title="Verified Store"><CheckBadgeIcon className="w-5 h-5 text-blue-500 flex-shrink-0" /></span>}
+                {store.verified && <span title="認証済み店舗"><CheckBadgeIcon className="w-5 h-5 text-blue-500 flex-shrink-0" /></span>}
             </div>
             <div className="flex items-center gap-1">
                 <StarIcon className="w-4 h-4 text-amber-400" />

--- a/components/InventoryDetailModal.tsx
+++ b/components/InventoryDetailModal.tsx
@@ -8,6 +8,15 @@ import { CheckBadgeIcon } from './icons/CheckBadgeIcon';
 import { TagIcon } from './icons/TagIcon';
 import { CubeIcon } from './icons/CubeIcon';
 
+const currencyFormatter = new Intl.NumberFormat('ja-JP', {
+  style: 'currency',
+  currency: 'JPY',
+  maximumFractionDigits: 0,
+});
+
+const formatPrizeGrade = (grade: InventoryItem['prize']['grade']): string =>
+  grade === 'Last One' ? 'ラストワン賞' : `${grade}賞`;
+
 interface InventoryDetailModalProps {
   item: InventoryItem;
   onClose: () => void;
@@ -48,10 +57,10 @@ export const InventoryDetailModal: React.FC<InventoryDetailModalProps> = ({ item
                 <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100">
                     <CheckBadgeIcon className="h-6 w-6 text-green-600" />
                 </div>
-                <h3 className="text-2xl font-bold text-slate-900 mt-4">Reservation Confirmed!</h3>
-                <p className="text-slate-600 mt-2">Your item is held for 24 hours. Check your notifications for details on pickup at <span className="font-semibold">{item.store.name}</span>.</p>
+                <h3 className="text-2xl font-bold text-slate-900 mt-4">予約が確定しました！</h3>
+                <p className="text-slate-600 mt-2">この景品は24時間お取り置きされます。受け取り方法の詳細は通知をご確認ください（店舗：<span className="font-semibold">{item.store.name}</span>）。</p>
                 <button onClick={onClose} className="mt-6 w-full bg-indigo-600 text-white font-semibold py-2 px-4 rounded-md hover:bg-indigo-700 transition">
-                    Done
+                    閉じる
                 </button>
             </div>
         </div>
@@ -78,7 +87,7 @@ export const InventoryDetailModal: React.FC<InventoryDetailModalProps> = ({ item
                 <img
                   key={index}
                   src={photo}
-                  alt={`Thumbnail ${index + 1}`}
+                  alt={`サムネイル${index + 1}`}
                   onClick={() => setActivePhoto(photo)}
                   className={`w-16 h-16 object-cover rounded-md cursor-pointer border-2 ${activePhoto === photo ? 'border-indigo-500' : 'border-transparent'}`}
                 />
@@ -91,20 +100,20 @@ export const InventoryDetailModal: React.FC<InventoryDetailModalProps> = ({ item
         <div className="w-full md:w-1/2 p-6 flex flex-col overflow-y-auto">
           <div className="flex-grow">
             <div className={`inline-block px-3 py-1 text-sm font-bold text-white rounded-full mb-2 ${isRare ? 'bg-amber-500' : 'bg-indigo-500'}`}>
-              {item.prize.grade} Prize
+              {formatPrizeGrade(item.prize.grade)}
             </div>
             <h2 className="text-3xl font-extrabold text-slate-900">{item.prize.title}</h2>
             <p className="text-md text-slate-500 mt-1">{item.prize.series}</p>
             
             <div className="my-6">
                 <div className="flex items-center gap-4 text-sm text-slate-700">
-                    <span className="flex items-center gap-1.5"><TagIcon className="w-5 h-5 text-indigo-500" /> Price: <span className="font-bold text-2xl text-indigo-600">${item.price.toFixed(2)}</span></span>
-                    <span className="flex items-center gap-1.5"><CubeIcon className="w-5 h-5 text-indigo-500" /> In Stock: <span className="font-bold">{item.quantity}</span></span>
+                    <span className="flex items-center gap-1.5"><TagIcon className="w-5 h-5 text-indigo-500" /> 価格: <span className="font-bold text-2xl text-indigo-600">{currencyFormatter.format(item.price)}</span></span>
+                    <span className="flex items-center gap-1.5"><CubeIcon className="w-5 h-5 text-indigo-500" /> 在庫数: <span className="font-bold">{item.quantity}</span></span>
                 </div>
             </div>
 
             <div className="bg-slate-50 p-4 rounded-lg">
-                <h4 className="font-bold text-lg text-slate-800 mb-2">Store Information</h4>
+                <h4 className="font-bold text-lg text-slate-800 mb-2">店舗情報</h4>
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                         <p className="font-semibold">{item.store.name}</p>
@@ -117,24 +126,27 @@ export const InventoryDetailModal: React.FC<InventoryDetailModalProps> = ({ item
                 </div>
                 <div className="text-sm text-slate-600 mt-2 flex items-start gap-1.5">
                     <MapPinIcon className="w-4 h-4 mt-0.5 flex-shrink-0" />
-                    <span>{item.store.address} ({item.store.distanceKm.toFixed(1)} km away)</span>
+                    <span>{item.store.address}（現在地から{item.store.distanceKm.toFixed(1)}km）</span>
                 </div>
             </div>
           </div>
-          
+
           <div className="mt-6 pt-6 border-t border-slate-200">
-             <p className="text-xs text-slate-500 mb-2 text-center">A small, refundable deposit of $3.00 is required. This will be deducted from the final price upon pickup.</p>
+             <p className="text-xs text-slate-500 mb-2 text-center">予約には返金可能なデポジット {currencyFormatter.format(300)} が必要です。受け取り時に合計金額から差し引かれます。</p>
             <button
               onClick={handleReservation}
               disabled={isReserving}
               className="w-full bg-indigo-600 text-white font-semibold py-3 px-4 rounded-md hover:bg-indigo-700 transition disabled:bg-indigo-300 disabled:cursor-not-allowed flex items-center justify-center"
             >
               {isReserving ? (
-                  <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
-              ) : 'Reserve with Deposit'}
+                  <>
+                    <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    予約処理中...
+                  </>
+              ) : 'デポジットで予約する'}
             </button>
           </div>
         </div>

--- a/components/InventoryList.tsx
+++ b/components/InventoryList.tsx
@@ -12,8 +12,8 @@ export const InventoryList: React.FC<InventoryListProps> = ({ items, onSelectCar
   if (items.length === 0) {
     return (
       <div className="text-center py-16 px-6 bg-white rounded-lg shadow-md">
-        <h3 className="text-xl font-semibold text-slate-800">No Results Found</h3>
-        <p className="text-slate-500 mt-2">Try adjusting your search filters to find more prizes.</p>
+        <h3 className="text-xl font-semibold text-slate-800">該当する在庫が見つかりませんでした</h3>
+        <p className="text-slate-500 mt-2">検索条件を変更して、別の在庫を探してみてください。</p>
       </div>
     );
   }
@@ -26,3 +26,4 @@ export const InventoryList: React.FC<InventoryListProps> = ({ items, onSelectCar
     </div>
   );
 };
+

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -26,7 +26,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
         {/* Search Query Input */}
         <div className="md:col-span-2">
           <label htmlFor="search-query" className="block text-sm font-medium text-slate-700 mb-1">
-            Title / Prize Name
+            タイトル・賞名
           </label>
           <div className="relative">
             <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -37,7 +37,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
               id="search-query"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="e.g., 'One Piece', 'Last One Prize'"
+              placeholder="例：「ワンピース」「ラストワン賞」"
               className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 transition"
             />
           </div>
@@ -47,7 +47,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label htmlFor="radius" className="block text-sm font-medium text-slate-700 mb-1">
-              Radius
+              検索範囲
             </label>
             <div className="relative">
                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -59,16 +59,16 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
                 onChange={(e) => setRadius(Number(e.target.value))}
                 className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 transition appearance-none"
               >
-                <option value={5}>5 km</option>
-                <option value={10}>10 km</option>
-                <option value={25}>25 km</option>
-                <option value={50}>50 km</option>
+                <option value={5}>5km</option>
+                <option value={10}>10km</option>
+                <option value={25}>25km</option>
+                <option value={50}>50km</option>
               </select>
             </div>
           </div>
           <div>
             <label htmlFor="prize-grade" className="block text-sm font-medium text-slate-700 mb-1">
-              Prize Grade
+              賞種
             </label>
             <div className="relative">
               <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -80,11 +80,11 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
                 onChange={(e) => setPrizeGrade(e.target.value as PrizeGrade | 'all')}
                 className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 transition appearance-none"
               >
-                <option value="all">All Grades</option>
-                <option value="A">A Prize</option>
-                <option value="B">B Prize</option>
-                <option value="C">C Prize</option>
-                <option value="Last One">Last One</option>
+                <option value="all">すべての賞</option>
+                <option value="A">A賞</option>
+                <option value="B">B賞</option>
+                <option value="C">C賞</option>
+                <option value="Last One">ラストワン賞</option>
               </select>
             </div>
           </div>
@@ -95,15 +95,15 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
           className="w-full bg-indigo-600 text-white font-semibold py-2 px-4 rounded-md hover:bg-indigo-700 transition flex items-center justify-center gap-2"
         >
           <SearchIcon className="h-5 w-5" />
-          Search
+          検索する
         </button>
       </form>
       
       {/* Sorting Options */}
       <div className="mt-4 flex flex-wrap gap-2 items-center">
-        <span className="text-sm font-medium text-slate-600">Sort by:</span>
+        <span className="text-sm font-medium text-slate-600">並び替え:</span>
         <div className="flex flex-wrap gap-2">
-        {([['score', 'Recommended'], ['distance', 'Distance'], ['price', 'Price'], ['newest', 'Newest']] as const).map(([value, label]) => (
+        {([['score', 'おすすめ'], ['distance', '距離が近い順'], ['price', '価格が安い順'], ['newest', '新着順']] as const).map(([value, label]) => (
             <button
               key={value}
               onClick={() => {
@@ -124,3 +124,4 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
     </div>
   );
 };
+

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,201 @@
+# 要件定義書（MVP→スケール）
+
+## 目的
+
+「不良在庫の一番くじ」と「それを今すぐ欲しい人」を、位置情報と在庫データで最短接続する。  
+在庫は罪ではない。情報の孤独だ。
+
+## 1. プロダクトビジョン & 成功指標
+
+**ビジョン**：全国の「眠るくじ」を“秒で見つかる資産”に変える。
+
+**主要KPI（MVP）**
+
+1. 掲載店舗数（週次）
+2. 在庫登録点数（週次）
+3. マッチング成立率＝予約/問合せ ÷ 在庫閲覧
+4. ノーショー率（来店/発送不履行）
+5. 在庫滞留日数の短縮（Before→After）
+
+## 2. ペルソナ（2面市場）
+
+- **店舗側**：ホビー/コンビニ/書店等。棚が圧迫、回転率を上げたい。写真撮影ならできる、複雑な操作はイヤ。
+- **ユーザー側**：推し景品のA賞/ラストワン狙い。遠征も辞さず。ただし確実性（取り置き/発送）が命。
+
+## 3. 価値仮説（メリット/デメリット）
+
+- **店舗メリット**：無料集客、在庫現金化、棚スペース回復。
+- **店舗デメリット**：撮影/登録の手間、ノーショーリスク。→超簡単登録＋予約デポジットで緩和。
+- **ユーザーメリット**：欲しい景品を最短発見、取り置き/発送の確実性。
+- **ユーザーデメリット**：送料・移動コスト。→距離×価格×在庫希少度の提示で意思決定支援。
+
+## 4. コア体験（ユーザーストーリー & 受入条件）
+
+### U1：欲しい景品のアラート
+
+- 条件：タイトル名/賞種/距離/価格上限を登録すると、在庫が出た瞬間にプッシュ通知。
+- 受入：通知到達 < 1分、在庫詳細画面へ1タップ。
+
+### U2：在庫一覧→予約
+
+- 条件：近い順・安い順・希少順の並び替え。写真3枚/賞種タグ/残数/取り置き可否を表示。
+- 受入：3秒以内にリスト表示、予約フロー3画面以内（選択→支払/デポ→完了）。
+
+### S1：店舗の“爆速”在庫登録
+
+- 条件：タイトル選択（サジェスト）→賞種&残数→写真→受け渡し方法（来店/発送/どちらも）→公開。
+- 受入：登録開始から公開まで90秒以内、必須項目未入力はガード。
+
+### S2：予約管理
+
+- 条件：○時間取り置き、デポジット徴収、期限切れ自動解放。
+- 受入：状態が「公開・予約中・受渡完了・期限切れ」に正しく遷移、ノーショー時はワンタップで復活公開。
+
+## 5. 機能要件（MVP→拡張）
+
+### MUST（MVP）
+
+- 位置情報検索（半径/都道府県）
+- タイトル/賞種検索、在庫カード（写真・残数・価格/条件）
+- 取り置き予約（有効期限・デポジット）
+- 店舗ダッシュボード（在庫登録・予約一覧・チャット）
+- プッシュ通知（新規在庫/予約状態）
+- 通報/ブロック、基本レビュー（星＋コメント）
+
+### SHOULD（次）
+
+- 発送対応（送料テンプレ、伝票番号入力）
+- ウィッシュリストの自動マッチング
+- 在庫一括CSV/写真まとめ登録
+- プロモーション枠（上位表示）
+
+### LATER
+
+- 公式API/提携、POS連携、価格推奨AI、需要予測、在庫自動撮影認識（OCR/画像分類）
+
+## 6. 非機能要件
+
+- パフォーマンス：主要クエリ P95 < 500ms、画像はCDN
+- 可用性：99.5%（MVP）
+- セキュリティ：JWT、行レベルセキュリティ、決済は外部（Stripe）
+- 監査：在庫変更/予約ログを保持 90日+
+
+## 7. マッチング仕様（初期アルゴリズム）
+
+スコア = w1 * 距離スコア + w2 * 希少度 + w3 * 価格スコア + w4 * 在庫鮮度 + w5 * レビュー
+
+- 距離スコア：0–1（近いほど高）
+- 希少度：A賞・ラストワン > 下位賞、残数が少ないほど高
+- 価格スコア：設定上限以下で線形↑
+- 鮮度：登録からの経過時間が短いほど高
+- レビュー：店舗星平均（閾値以下は減点）
+
+※ 重みは A/B テストで学習。初期値は w1 = 0.35, w2 = 0.25, w3 = 0.2, w4 = 0.15, w5 = 0.05。
+
+## 8. データモデル（ER 概要）
+
+- `users(id, role[user|store|admin], name, phone, geo_point, push_token, …)`
+- `stores(id, owner_user_id, name, address, geo_point, verified, shipping_supported, …)`
+- `titles(id, name, series, release_date, official_code)`
+- `prizes(id, title_id, grade[A…], label, msrp)`
+- `inventories(id, store_id, prize_id, qty, price, photos[], status[public|reserved|sold], hold_policy{hours})`
+- `wishlists(id, user_id, prize_id, radius_km, price_cap)`
+- `reservations(id, inventory_id, user_id, status[pending|paid|picked|expired|noshow], expires_at, deposit_amount, handover[visit|ship], tracking_no)`
+- `messages(id, reservation_id, sender_id, body, created_at)`
+- `reviews(id, target_store_id, user_id, stars, comment)`
+- `reports(id, target_type, target_id, reason, status)`
+
+地理検索は PostGIS（Supabase）で ST_DWithin。画像は Supabase Storage or S3。
+
+## 9. API 設計（REST）
+
+- `POST /auth/signup | /auth/login`
+- `GET /titles?query=`
+- `GET /prizes?title_id=`
+- `GET /inventories?lat&lng&radius&title_id&prize_grade&sort=`
+- `POST /stores/{id}/inventories`（店舗）
+- `POST /reservations`
+- `PATCH /reservations/{id}`（confirm/cancel/pickup/noshow）
+- `POST /reports`
+- `POST /reviews`
+- `GET /me/notifications`（既読管理）
+
+## 10. 画面一覧（要素のみ）
+
+- **ユーザー**：ホーム（近場在庫）、詳細、予約フロー、ウィッシュ、通知、マイページ
+- **店舗**：在庫リスト、在庫登録（カメラ→自動タイトル推定の補助）、予約一覧、チャット
+- **管理**：通報・レビュー・店舗承認
+
+## 11. 予約・決済・ノーショー対策
+
+- デポジット（¥300–¥1000可変）→来店時値引き/発送時相殺。未履行は店舗へ一定率分配。
+- 予約期限：デフォ 24h（店舗設定可）。期限切れ自動解放。
+- ノーショーフラグが閾値超で一時的に予約前支払のみへ移行。
+- 店舗は「写真＋手書きメモ（日時/残数）」で掲載信頼スコアを上げる。
+
+## 12. 法務・運用留意
+
+- 「一番くじ」は登録商標。アプリ名は汎称（例：KujiLink/KujiMatch）、表記は“対応タイトル”とする。
+- 公式サイトや小売サイトのスクレイピングは TOS/robots 準拠。MVP は店舗自己申告＋写真を主軸。
+- 古物営業・転売規制の確認（発送を店舗起点に限定、個人間売買は非対応から開始）。
+
+## 13. 立ち上げ戦略（鶏卵割り）
+
+- 供給先行：在庫が出やすいエリア（例：東海→静岡・愛知）に特化、店舗を手厚くオンボード。
+- テンプレ撮影キット（台紙 A4・撮影例）＋初回掲載で上位表示。
+- 需要側はアラート機能でコミュニティ流入（X/Discord）。
+- 週次で「完売ストーリー」を SNS に回し社会的証明。
+
+## 14. 収益化（MVP は無料→段階課金）
+
+- 予約デポ事務手数料（数％）
+- 店舗プレミアム（上位表示・一括登録・スタッフ複数権限）
+- プロモ投稿（地域ヘッダー固定）
+- 将来：データ洞察（仕入れ最適化レポート）
+
+## 15. 技術スタック
+
+- フロント：Next.js（React）+ TypeScript、Expo（後で RN アプリ化）
+- 認証：Supabase Auth（OTP/SMS）
+- DB：Supabase（Postgres + PostGIS）+ Prisma
+- ストレージ/CDN：Supabase Storage
+- 決済：Stripe（PaymentIntent + デポ）
+- 通知：Expo Push / OneSignal
+- デプロイ：Vercel（API Routes）
+- 監視：Sentry, Logflare（SQL 監視）
+
+## 16. 開発計画（4 スプリント / 4–6 週）
+
+1. S1：認証・店舗在庫登録・一覧検索（地理）
+2. S2：詳細/予約/デポジット/通知
+3. S3：ダッシュボード・通報/レビュー・ノーショー制御
+4. S4：UI 磨き・負荷試験・β 公開（静岡/愛知 50 店舗目標）
+
+## 17. Codex 用プロンプト
+
+1. **Prisma スキーマ生成**
+   - 「Prisma で Postgres 用 schema を書いて。entities: users, stores, titles, prizes, inventories, wishlists, reservations, messages, reviews, reports。users は role(enum)、geo は PostGIS の geometry(Point,4326) は別カラム lat,lng で。RLS 前提の簡易モデルで。」
+2. **地理検索 API（Next.js / api/inventories/search）**
+   - 「Next.js API Route で GET /api/inventories/search を実装。params: lat,lng,radius_km,title_id,grade,sort。Prisma で距離計算は earth_distance(ll_to_earth(...)) 拡張を使わず、単純ハバースイン近似で ORDER。P95 < 500ms を目標に LIMIT 50。」
+3. **予約フロー**
+   - 「POST /api/reservations で Stripe PaymentIntent（deposit）を作成、expires_at を設定、在庫を reserved へ原子的更新（トランザクション）。Webhooks で paid→reserved 確定、expired→public へ戻すハンドラを実装。」
+4. **画像アップロード**
+   - 「Supabase Storage に署名付 URL を発行し、フロントから直アップ。3 枚まで、1 枚 2MB まで、webp へ変換（フロントで）」
+5. **通知**
+   - 「在庫作成時、該当ウィッシュリストを半径＆価格で絞り、対象ユーザーの push_token に Expo Push を送る関数 notifyWishlistHit() を実装。」
+
+## 18. 受入テスト（抜粋）
+
+- 在庫登録 90 秒チャレンジ：新規店舗アカウントで、タイトル検索→賞種入力→写真→公開まで 90 秒以内。
+- マッチ通知：指定タイトルのウィッシュを登録し、在庫公開から 60 秒以内に端末へ通知。
+- ノーショー：期限超過で自動解放・デポ没収ロジックがログで検証できる。
+- RLS：他店舗が他人の在庫を更新できないこと。
+
+## 19. リスクと対策
+
+- 商標/権利：名称の中立化、公式への配慮、画像の出典/撮影ルール。
+- 虚偽在庫：店舗認証、写真必須、ユーザー通報→非表示、スコア減点。
+- ノーショー：デポ必須・履歴に応じて前払い化。
+- 鶏卵問題：地域特化 + 店舗支援キット + 上位表示インセンティブ。
+- 個人転売化：MVP は店舗アカウント限定で開始。
+

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>KujiLink - Find Your Prize</title>
+    <title>KujiLink - 欲しいくじをすぐに見つける</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
     <style>
@@ -27,3 +27,4 @@
     <script type="module" src="/index.tsx"></script>
   </body>
 </html>
+

--- a/services/mockApi.ts
+++ b/services/mockApi.ts
@@ -2,37 +2,37 @@
 import type { InventoryItem, SearchFilters, SortOption, PrizeGrade } from '../types';
 
 const samplePrizes = [
-    { id: 'p1', title: 'Monkey D. Luffy Figure - Gear 5', series: 'One Piece - Emotional Stories 2', grade: 'A' as PrizeGrade },
-    { id: 'p2', title: 'Trafalgar Law Figure - Emotional Stories', series: 'One Piece - Emotional Stories 2', grade: 'B' as PrizeGrade },
-    { id: 'p3', title: 'Last One - Special Luffy Figure', series: 'One Piece - Emotional Stories 2', grade: 'Last One' as PrizeGrade },
-    { id: 'p4', title: 'Gojo Satoru Figure - Shibuya Incident', series: 'Jujutsu Kaisen - Hidden Inventory', grade: 'A' as PrizeGrade },
-    { id: 'p5', title: 'Geto Suguru Figure - Shibuya Incident', series: 'Jujutsu Kaisen - Hidden Inventory', grade: 'B' as PrizeGrade },
-    { id: 'p6', 'title': 'Tanjiro Kamado Figure', series: 'Demon Slayer - To the Swordsmith Village', grade: 'A' as PrizeGrade },
-    { id: 'p7', 'title': 'Nezuko Kamado Figure', series: 'Demon Slayer - To the Swordsmith Village', grade: 'B' as PrizeGrade },
-    { id: 'p8', 'title': 'Big Towel Collection', series: 'Jujutsu Kaisen - Hidden Inventory', grade: 'C' as PrizeGrade },
-    { id: 'p9', 'title': 'Acrylic Stand Set', series: 'One Piece - Emotional Stories 2', grade: 'D' as PrizeGrade },
-    { id: 'p10', 'title': 'Rubber Charm Collection', series: 'Demon Slayer - To the Swordsmith Village', grade: 'E' as PrizeGrade }
+    { id: 'p1', title: 'モンキー・D・ルフィ フィギュア ギア5', series: 'ワンピース 一番くじ Emotional Stories 2', grade: 'A' as PrizeGrade },
+    { id: 'p2', title: 'トラファルガー・ロー フィギュア', series: 'ワンピース 一番くじ Emotional Stories 2', grade: 'B' as PrizeGrade },
+    { id: 'p3', title: 'ラストワン賞 スペシャルルフィフィギュア', series: 'ワンピース 一番くじ Emotional Stories 2', grade: 'Last One' as PrizeGrade },
+    { id: 'p4', title: '五条悟 フィギュア 渋谷事変', series: '呪術廻戦 一番くじ 渋谷事変編', grade: 'A' as PrizeGrade },
+    { id: 'p5', title: '夏油傑 フィギュア 渋谷事変', series: '呪術廻戦 一番くじ 渋谷事変編', grade: 'B' as PrizeGrade },
+    { id: 'p6', title: '竈門炭治郎 フィギュア', series: '鬼滅の刃 一番くじ 刀鍛冶の里編', grade: 'A' as PrizeGrade },
+    { id: 'p7', title: '竈門禰豆子 フィギュア', series: '鬼滅の刃 一番くじ 刀鍛冶の里編', grade: 'B' as PrizeGrade },
+    { id: 'p8', title: 'ビッグタオルコレクション', series: '呪術廻戦 一番くじ 渋谷事変編', grade: 'C' as PrizeGrade },
+    { id: 'p9', title: 'アクリルスタンドセット', series: 'ワンピース 一番くじ Emotional Stories 2', grade: 'D' as PrizeGrade },
+    { id: 'p10', title: 'ラバーチャームコレクション', series: '鬼滅の刃 一番くじ 刀鍛冶の里編', grade: 'E' as PrizeGrade }
 ];
 
 const sampleStores = [
-    { id: 's1', name: 'Hobby Shop Akiba', address: '123 Anime St, Chiyoda', distanceKm: 1.2, rating: 4.8, verified: true },
-    { id: 's2', name: '7-Eleven Ikebukuro', address: '456 Otome Rd, Toshima', distanceKm: 3.5, rating: 4.2, verified: false },
-    { id: 's3', name: 'BookOff Shinjuku', address: '789 West Gate, Shinjuku', distanceKm: 8.1, rating: 4.5, verified: true },
-    { id: 's4', name: 'Toy Planet Nakano', address: '101 Broadway, Nakano', distanceKm: 5.5, rating: 4.9, verified: true },
-    { id: 's5', name: 'FamilyMart Shibuya', address: '222 Scramble, Shibuya', distanceKm: 12.3, rating: 4.0, verified: false },
+    { id: 's1', name: 'ホビーショップ秋葉原本店', address: '東京都千代田区外神田1-1-1', distanceKm: 1.2, rating: 4.8, verified: true },
+    { id: 's2', name: 'セブン-イレブン池袋東口店', address: '東京都豊島区東池袋3-3-3', distanceKm: 3.5, rating: 4.2, verified: false },
+    { id: 's3', name: 'ブックオフ新宿西口店', address: '東京都新宿区西新宿1-2-3', distanceKm: 8.1, rating: 4.5, verified: true },
+    { id: 's4', name: 'トイプラネット中野店', address: '東京都中野区中野5-52-15', distanceKm: 5.5, rating: 4.9, verified: true },
+    { id: 's5', name: 'ファミリーマート渋谷駅前店', address: '東京都渋谷区道玄坂2-1-1', distanceKm: 12.3, rating: 4.0, verified: false },
 ];
 
 const mockInventory: InventoryItem[] = [
-    { id: 'inv1', store: sampleStores[0], prize: samplePrizes[0], quantity: 1, price: 45.00, photos: ['https://picsum.photos/seed/inv1/600/400'], status: 'public', registeredAt: new Date('2023-10-26T10:00:00Z') },
-    { id: 'inv2', store: sampleStores[1], prize: samplePrizes[3], quantity: 2, price: 50.00, photos: ['https://picsum.photos/seed/inv2/600/400'], status: 'public', registeredAt: new Date('2023-10-25T14:00:00Z') },
-    { id: 'inv3', store: sampleStores[2], prize: samplePrizes[2], quantity: 1, price: 80.00, photos: ['https://picsum.photos/seed/inv3/600/400'], status: 'public', registeredAt: new Date('2023-10-26T12:00:00Z') },
-    { id: 'inv4', store: sampleStores[3], prize: samplePrizes[1], quantity: 3, price: 30.00, photos: ['https://picsum.photos/seed/inv4/600/400'], status: 'public', registeredAt: new Date('2023-10-20T09:00:00Z') },
-    { id: 'inv5', store: sampleStores[0], prize: samplePrizes[4], quantity: 1, price: 35.00, photos: ['https://picsum.photos/seed/inv5/600/400'], status: 'public', registeredAt: new Date('2023-10-26T11:00:00Z') },
-    { id: 'inv6', store: sampleStores[4], prize: samplePrizes[5], quantity: 2, price: 40.00, photos: ['https://picsum.photos/seed/inv6/600/400'], status: 'public', registeredAt: new Date('2023-10-24T18:00:00Z') },
-    { id: 'inv7', store: sampleStores[1], prize: samplePrizes[8], quantity: 10, price: 10.00, photos: ['https://picsum.photos/seed/inv7/600/400'], status: 'public', registeredAt: new Date('2023-10-15T10:00:00Z') },
-    { id: 'inv8', store: sampleStores[3], prize: samplePrizes[6], quantity: 1, price: 42.00, photos: ['https://picsum.photos/seed/inv8/600/400'], status: 'public', registeredAt: new Date('2023-10-26T08:00:00Z') },
-    { id: 'inv9', store: sampleStores[2], prize: samplePrizes[7], quantity: 5, price: 12.00, photos: ['https://picsum.photos/seed/inv9/600/400'], status: 'public', registeredAt: new Date('2023-10-22T13:00:00Z') },
-    { id: 'inv10', store: sampleStores[4], prize: samplePrizes[9], quantity: 8, price: 8.00, photos: ['https://picsum.photos/seed/inv10/600/400'], status: 'public', registeredAt: new Date('2023-10-23T16:00:00Z') },
+    { id: 'inv1', store: sampleStores[0], prize: samplePrizes[0], quantity: 1, price: 4500, photos: ['https://picsum.photos/seed/inv1/600/400'], status: 'public', registeredAt: new Date('2023-10-26T10:00:00Z') },
+    { id: 'inv2', store: sampleStores[1], prize: samplePrizes[3], quantity: 2, price: 5200, photos: ['https://picsum.photos/seed/inv2/600/400'], status: 'public', registeredAt: new Date('2023-10-25T14:00:00Z') },
+    { id: 'inv3', store: sampleStores[2], prize: samplePrizes[2], quantity: 1, price: 8800, photos: ['https://picsum.photos/seed/inv3/600/400'], status: 'public', registeredAt: new Date('2023-10-26T12:00:00Z') },
+    { id: 'inv4', store: sampleStores[3], prize: samplePrizes[1], quantity: 3, price: 3200, photos: ['https://picsum.photos/seed/inv4/600/400'], status: 'public', registeredAt: new Date('2023-10-20T09:00:00Z') },
+    { id: 'inv5', store: sampleStores[0], prize: samplePrizes[4], quantity: 1, price: 3800, photos: ['https://picsum.photos/seed/inv5/600/400'], status: 'public', registeredAt: new Date('2023-10-26T11:00:00Z') },
+    { id: 'inv6', store: sampleStores[4], prize: samplePrizes[5], quantity: 2, price: 4200, photos: ['https://picsum.photos/seed/inv6/600/400'], status: 'public', registeredAt: new Date('2023-10-24T18:00:00Z') },
+    { id: 'inv7', store: sampleStores[1], prize: samplePrizes[8], quantity: 10, price: 1200, photos: ['https://picsum.photos/seed/inv7/600/400'], status: 'public', registeredAt: new Date('2023-10-15T10:00:00Z') },
+    { id: 'inv8', store: sampleStores[3], prize: samplePrizes[6], quantity: 1, price: 4800, photos: ['https://picsum.photos/seed/inv8/600/400'], status: 'public', registeredAt: new Date('2023-10-26T08:00:00Z') },
+    { id: 'inv9', store: sampleStores[2], prize: samplePrizes[7], quantity: 5, price: 1500, photos: ['https://picsum.photos/seed/inv9/600/400'], status: 'public', registeredAt: new Date('2023-10-22T13:00:00Z') },
+    { id: 'inv10', store: sampleStores[4], prize: samplePrizes[9], quantity: 8, price: 900, photos: ['https://picsum.photos/seed/inv10/600/400'], status: 'public', registeredAt: new Date('2023-10-23T16:00:00Z') },
 ];
 
 const calculateScore = (item: InventoryItem, maxDistance: number): number => {
@@ -72,7 +72,7 @@ const calculateScore = (item: InventoryItem, maxDistance: number): number => {
 };
 
 export const searchInventory = (filters: SearchFilters, sort: SortOption): Promise<InventoryItem[]> => {
-    console.log('Searching with filters:', filters, 'and sort:', sort);
+    console.log('検索条件:', filters, '並び順:', sort);
     return new Promise((resolve) => {
         setTimeout(() => {
             let results = mockInventory.filter(item => item.status === 'public');
@@ -115,3 +115,4 @@ export const searchInventory = (filters: SearchFilters, sort: SortOption): Promi
         }, 800); // Simulate network latency
     });
 };
+


### PR DESCRIPTION
## Summary
- translate the landing view and global layout copy to Japanese to align with localized experience
- localize search controls, inventory cards, and detail modals with Japanese text plus yen currency formatting
- update mock inventory data to use Japanese prize and store names with yen pricing values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9429572548330b0e02e6f17f95451